### PR TITLE
Fix for NumPy version 1.20+: replace “numpy.bool” by “bool”

### DIFF
--- a/xmlplot/common.py
+++ b/xmlplot/common.py
@@ -141,7 +141,7 @@ def getMergedMask(*sources):
     mask = None
     def addmask(mask,newmask):
         if mask is None:
-            mask = numpy.empty(shape,dtype=numpy.bool)
+            mask = numpy.empty(shape,dtype=bool)
             mask[...] = newmask
         else:
             mask |= newmask

--- a/xmlplot/data/netcdf.py
+++ b/xmlplot/data/netcdf.py
@@ -1582,7 +1582,7 @@ class NetCDFStore_GOTM(NetCDFStore):
                 def setmask(mask,newmask):
                     if mask is numpy.ma.nomask:
                         # Create new depth mask based on provided mask, allowing for broadcasting.
-                        mask = numpy.empty(shape,dtype=numpy.bool)
+                        mask = numpy.empty(shape,dtype=bool)
                         mask[...] = newmask
                     else:
                         # Combine provided mask with existing one.


### PR DESCRIPTION
Since NumPy version 1.20.0, usage of “numpy.bool” is deprecated.  The equivalent “bool”, which is a normal data type in Python, should be used instead. This causes problems for newer versions of NumPy, e.g., version 1.24.1.

In this commit, “numpy.bool” is replaced by “bool” for compatibility with newer versions of NumPy.  To my knowledge, this is fully compatible with older versions, too.

More information: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations